### PR TITLE
Correcting whitespace in the Readme

### DIFF
--- a/SimpleKafkaStreaming/README.md
+++ b/SimpleKafkaStreaming/README.md
@@ -28,8 +28,8 @@ If you do not have a local zookeeper, make sure to use the IP address of one of 
     su - kafka
     /usr/hdp/current/kafka-broker/bin/kafka-topics.sh \
         --create --zookeeper localhost:2181 \
-        --replication-factor 1 \ 
-        --partitions 1 \ 
+        --replication-factor 1 \
+        --partitions 1 \
         --topic sparkstreaming
 
 You can check if the topic now exists:


### PR DESCRIPTION
With the existing whitespace, CRs are not escaped, so copy pasting the command will not work.
